### PR TITLE
Add FlexLift privacy policy page

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -34,6 +34,13 @@ module.exports = {
       },
     },
     {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        path: `${__dirname}/privacy`,
+        name: `privacy`,
+      },
+    },
+    {
       resolve: `gatsby-transformer-remark`,
       options: {
         plugins: [

--- a/privacy/flex-lift.md
+++ b/privacy/flex-lift.md
@@ -163,9 +163,9 @@ FlexLift is designed for users worldwide. Since we do not collect personal infor
 
 If you have any questions about this Privacy Policy or FlexLift's privacy practices, please contact us:
 
-**Email:** privacy@flexlift.app  
-**Website:** https://flexlift.app/privacy  
-**Support:** https://flexlift.app/support
+**Email:** joshua@joshuacolvin.net
+**Website:** https://www.joshuacolvin.net/apps/flexlift/privacy
+**Support:** joshua@joshuacolvin.net
 
 ## Legal Compliance
 
@@ -235,5 +235,5 @@ Your privacy is our priority. FlexLift is designed to help you track your workou
 ---
 
 **FlexLift Privacy Policy v1.0**  
-**Effective Date:** December 2024  
-**Contact:** privacy@flexlift.app
+**Effective Date:** October 2025
+**Contact:** joshua@joshuacolvin.net

--- a/src/pages/apps/flexlift/privacy.js
+++ b/src/pages/apps/flexlift/privacy.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import { graphql } from 'gatsby'
+
+import Layout from '../../../components/Layout'
+import SEO from '../../../components/seo'
+
+const FlexLiftPrivacyPage = ({ data, location }) => {
+  const { site, markdownRemark } = data
+  const siteTitle = site.siteMetadata.title
+  const policy = markdownRemark
+
+  return (
+    <Layout location={location} title={siteTitle}>
+      <SEO title="FlexLift Privacy Policy" description={policy.excerpt} />
+      <article dangerouslySetInnerHTML={{ __html: policy.html }} />
+    </Layout>
+  )
+}
+
+export default FlexLiftPrivacyPage
+
+export const pageQuery = graphql`
+  query FlexLiftPrivacyPage {
+    site {
+      siteMetadata {
+        title
+      }
+    }
+    markdownRemark(fileAbsolutePath: { regex: "/privacy/flex-lift.md$/" }) {
+      html
+      excerpt(pruneLength: 160)
+    }
+  }
+`


### PR DESCRIPTION
## Summary
- add the privacy markdown directory to Gatsby's data sources
- create a dedicated page at /apps/flexlift/privacy that renders the FlexLift policy content
- update the FlexLift privacy policy contact details to use joshua@joshuacolvin.net, October 2025 effective date, and the new hosted URL

## Testing
- yarn lint *(fails: Yarn 4 workspace lookup error due to missing lockfile entry)*

------
https://chatgpt.com/codex/tasks/task_e_68e02595d2c48322aecd271423fc8fe4